### PR TITLE
Fix 4.20 build error

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -335,8 +335,8 @@ static const struct ieee80211_txrx_stypes
 static u64 rtw_get_systime_us(void)
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39))
-	struct timespec ts;
-	get_monotonic_boottime(&ts);
+	struct timespec64 ts;
+	ktime_get_boottime_ts64(&ts);
 	return ((u64)ts.tv_sec * 1000000) + ts.tv_nsec / 1000;
 #else
 	struct timeval tv;


### PR DESCRIPTION
Taken from https://github.com/zebulon2/rtl8814au/commit/c9a20dcb10fb72dc38a5bffc52a538fd26571dc0, which, in turn, was taken from comment at https://aur.archlinux.org/packages/rtl8814au-dkms-git/, made by @Gatenkaas. Should fix #12.