### PR TITLE
Updated Kernel Calls for Linux >= 5.0

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -335,8 +335,8 @@ static const struct ieee80211_txrx_stypes
 static u64 rtw_get_systime_us(void)
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39))
-	struct timespec ts;
-	get_monotonic_boottime(&ts);
+	struct timespec64 ts;
+	ktime_get_boottime_ts64(&ts);
 	return ((u64)ts.tv_sec * 1000000) + ts.tv_nsec / 1000;
 #else
 	struct timeval tv;

--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -626,7 +626,7 @@ int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd)
 		goto exit;
 	}
 
-	if (!access_ok(VERIFY_READ, priv_cmd.buf, priv_cmd.total_len)) {
+	if (!access_ok(priv_cmd.buf, priv_cmd.total_len)) {
 		RTW_INFO("%s: failed to access memory\n", __FUNCTION__);
 		ret = -EFAULT;
 		goto exit;


### PR DESCRIPTION
Fixed some of the system calls.

It only works for kernel 5.0 and above.
Do not use this for lower kernel versions.

Although this should be editable by manually checking the linux kernel version and then creating a typedef struct.